### PR TITLE
added maven-compiler-plugin reference to 3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.2</version>
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Made compiler plugin use the latest version

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.0.2:compile (default-compile) on project scoring: Compilation failure: Compilation failure:
[ERROR] /home/rajesh/work/projects/os/Surus/src/main/java/org/surus/pig/ScorePMML.java:[38,39] error: generics are not supported in -source 1.3
[ERROR] 
[ERROR] (use -source 5 or higher to enable generics)
[ERROR] /home/rajesh/work/projects/os/Surus/src/main/java/org/surus/pig/ScorePMML.java:[65,24] error: variable-arity methods are not supported in -source 1.3
[ERROR] 
[ERROR] (use -source 5 or higher to enable variable-arity methods)
[ERROR] /home/rajesh/work/projects/os/Surus/src/main/java/org/surus/pig/ScorePMML.java:[109,21] error: for-each loops are not supported in -source 1.3
[ERROR] 
[ERROR] (use -source 5 or higher to enable for-each loops)
[ERROR] /home/rajesh/work/projects/os/Surus/src/main/java/org/surus/pig/ScorePMML.java:[166,5] error: annotations are not supported in -source 1.3
