### PR TITLE
Update RAD.java to account for null isForceDiff

### DIFF
--- a/src/main/java/org/surus/pig/RAD.java
+++ b/src/main/java/org/surus/pig/RAD.java
@@ -178,7 +178,7 @@ public class RAD extends EvalFunc<DataBag> {
 			if (this.isForceDiff == null && dickeyFullerTest.isNeedsDiff()) {
 				// Auto Diff
 				inputArrayTransformed = dickeyFullerTest.getZeroPaddedDiff();
-			} else if (this.isForceDiff) {
+			} else if (Boolean.TRUE.equals(this.isForceDiff)) {
 				// Force Diff
 				inputArrayTransformed = dickeyFullerTest.getZeroPaddedDiff();
 			}


### PR DESCRIPTION
The constructor for the class RAD expects an optional argument for the class member isForceDiff which is a Boolean wrapper (line 46). If the argument is not passed in, the member stays null.

line 46: this.isForceDiff = Boolean.parseBoolean(parameters[3]);

This throws an NPE at line 181 where the code checks if (this.isForceDiff).
line 181: } else if (this.isForceDiff) {

To overcome this, isForceDiff has to be passed at least as False.

Fix: The code should check for null at line 181 or make isForceDiff primitive for it to default to false.

Raised an issue at https://github.com/Netflix/Surus/issues/11